### PR TITLE
fixed numeric node identifier lookup and added it to the path algorithms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ### Bug Fixes
 1. Update mcp dependency to 2.0.
 2. Remove the stale example requirements file that was only example `import_data.py`
+3. Use exact node identifier matching and allow numeric identifier inputs across graph algorithms.

--- a/mcp_server/src/mcp_server_neo4j_gds/centrality_algorithm_specs.py
+++ b/mcp_server/src/mcp_server_neo4j_gds/centrality_algorithm_specs.py
@@ -23,7 +23,7 @@ centrality_tool_definitions = [
                 },
                 "nodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of node to filter return the ArticleRank for.",
                 },
                 "nodeIdentifierProperty": {
@@ -49,7 +49,7 @@ centrality_tool_definitions = [
                 "sourceNodes": {
                     "description": "The nodes to use for computing Personalized Article Rank.",
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                 },
                 "scaler": {
                     "type": "string",
@@ -109,7 +109,7 @@ centrality_tool_definitions = [
                 },
                 "nodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of node names to filter betweenness centrality results for.",
                 },
                 "nodeIdentifierProperty": {
@@ -209,7 +209,7 @@ centrality_tool_definitions = [
                 },
                 "nodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of node names to filter closeness centrality results for.",
                 },
                 "nodeIdentifierProperty": {
@@ -245,7 +245,7 @@ centrality_tool_definitions = [
                 },
                 "nodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of node names to filter degree centrality results for.",
                 },
                 "nodeIdentifierProperty": {
@@ -293,7 +293,7 @@ centrality_tool_definitions = [
                 },
                 "nodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of node names to filter eigenvector centrality results for.",
                 },
                 "nodeIdentifierProperty": {
@@ -315,7 +315,7 @@ centrality_tool_definitions = [
                 "sourceNodes": {
                     "description": "The nodes to use for computing Personalized Eigenvector Centrality.",
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                 },
                 "scaler": {
                     "type": "string",
@@ -348,7 +348,7 @@ centrality_tool_definitions = [
                 },
                 "nodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of node names to filter PageRank results for.",
                 },
                 "nodeIdentifierProperty": {
@@ -370,7 +370,7 @@ centrality_tool_definitions = [
                 "sourceNodes": {
                     "description": "The nodes to use for computing Personalized PageRank.",
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                 },
             },
             "required": ["graphName"],
@@ -398,7 +398,7 @@ centrality_tool_definitions = [
                 },
                 "nodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of node names to filter harmonic centrality results for.",
                 },
                 "nodeIdentifierProperty": {
@@ -432,7 +432,7 @@ centrality_tool_definitions = [
                 },
                 "nodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of node names to filter HITS results for.",
                 },
                 "nodeIdentifierProperty": {

--- a/mcp_server/src/mcp_server_neo4j_gds/community_algorithm_specs.py
+++ b/mcp_server/src/mcp_server_neo4j_gds/community_algorithm_specs.py
@@ -371,8 +371,8 @@ community_tool_definitions = [
                 },
                 "nodes": {
                     "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Optional list of node names to filter results. Only nodes whose names (based on nodeIdentifierProperty) contain any of these values will be included in the results. Requires nodeIdentifierProperty to be specified.",
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
+                    "description": "Optional list of node identifiers to filter results. Matching is exact. Requires nodeIdentifierProperty to be specified.",
                 },
             },
             "required": ["graphName"],
@@ -586,8 +586,8 @@ community_tool_definitions = [
                 },
                 "nodes": {
                     "type": "array",
-                    "items": {"type": "string"},
-                    "description": "Optional list of node names to filter results. Only nodes whose names (based on nodeIdentifierProperty) contain any of these values will be included in the results. Requires nodeIdentifierProperty to be specified.",
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
+                    "description": "Optional list of node identifiers to filter results. Matching is exact. Requires nodeIdentifierProperty to be specified.",
                 },
             },
             "required": ["graphName"],

--- a/mcp_server/src/mcp_server_neo4j_gds/node_translator.py
+++ b/mcp_server/src/mcp_server_neo4j_gds/node_translator.py
@@ -16,62 +16,19 @@ def _replace_dataframe_contents(target, source):
     target.attrs.update(source.attrs)
 
 
-def _to_number(value):
-    """Return int/float if value is numeric; otherwise None."""
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, (int, float)):
-        return value
-    if isinstance(value, str):
-        s = value.strip()
-        try:
-            return int(s)
-        except ValueError:
-            try:
-                return float(s)
-            except ValueError:
-                return None
-    return None
-
-
 def _lookup_node_ids(gds, values, property_name):
-    """Resolve identifier values to Neo4j ids.
-
-    Numerics use exact ``=`` (toLower fails on number properties).
-    Strings use case-insensitive CONTAINS.
-    """
+    """Resolve identifier values to Neo4j ids using exact ``=``."""
     if not isinstance(values, list):
         values = [values]
 
-    numeric_values = []
-    string_values = []
-    for value in values:
-        numeric = _to_number(value)
-        if numeric is not None:
-            numeric_values.append(numeric)
-        else:
-            string_values.append(value)
-
-    node_ids = []
-    if numeric_values:
-        query = f"""
-                UNWIND $names AS name
-                MATCH (s)
-                WHERE s.{property_name} = name
-                RETURN id(s) as node_id
-                """
-        df = gds.run_cypher(query, params={"names": numeric_values})
-        node_ids.extend(df["node_id"].tolist())
-    if string_values:
-        query = f"""
-                UNWIND $names AS name
-                MATCH (s)
-                WHERE toLower(s.{property_name}) CONTAINS toLower(name)
-                RETURN id(s) as node_id
-                """
-        df = gds.run_cypher(query, params={"names": string_values})
-        node_ids.extend(df["node_id"].tolist())
-    return node_ids
+    query = f"""
+            UNWIND $names AS name
+            MATCH (s)
+            WHERE s.{property_name} = name
+            RETURN id(s) as node_id
+            """
+    df = gds.run_cypher(query, params={"names": values})
+    return df["node_id"].tolist()
 
 
 def translate_identifiers_to_ids(

--- a/mcp_server/src/mcp_server_neo4j_gds/node_translator.py
+++ b/mcp_server/src/mcp_server_neo4j_gds/node_translator.py
@@ -16,6 +16,64 @@ def _replace_dataframe_contents(target, source):
     target.attrs.update(source.attrs)
 
 
+def _to_number(value):
+    """Return int/float if value is numeric; otherwise None."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        s = value.strip()
+        try:
+            return int(s)
+        except ValueError:
+            try:
+                return float(s)
+            except ValueError:
+                return None
+    return None
+
+
+def _lookup_node_ids(gds, values, property_name):
+    """Resolve identifier values to Neo4j ids.
+
+    Numerics use exact ``=`` (toLower fails on number properties).
+    Strings use case-insensitive CONTAINS.
+    """
+    if not isinstance(values, list):
+        values = [values]
+
+    numeric_values = []
+    string_values = []
+    for value in values:
+        numeric = _to_number(value)
+        if numeric is not None:
+            numeric_values.append(numeric)
+        else:
+            string_values.append(value)
+
+    node_ids = []
+    if numeric_values:
+        query = f"""
+                UNWIND $names AS name
+                MATCH (s)
+                WHERE s.{property_name} = name
+                RETURN id(s) as node_id
+                """
+        df = gds.run_cypher(query, params={"names": numeric_values})
+        node_ids.extend(df["node_id"].tolist())
+    if string_values:
+        query = f"""
+                UNWIND $names AS name
+                MATCH (s)
+                WHERE toLower(s.{property_name}) CONTAINS toLower(name)
+                RETURN id(s) as node_id
+                """
+        df = gds.run_cypher(query, params={"names": string_values})
+        node_ids.extend(df["node_id"].tolist())
+    return node_ids
+
+
 def translate_identifiers_to_ids(
     gds: GraphDataScience,
     input_nodes,
@@ -26,36 +84,13 @@ def translate_identifiers_to_ids(
     # Handle input nodes - convert names to IDs if nodeIdentifierProperty is provided
     if input_nodes is not None and node_identifier_property is not None:
         if isinstance(input_nodes, list):
-            # Handle list of node names
-            query = f"""
-                    UNWIND $names AS name
-                    MATCH (s)
-                    WHERE toLower(s.{node_identifier_property}) = toLower(name)
-                    RETURN id(s) as node_id
-                    """
-            df = gds.run_cypher(
-                query,
-                params={
-                    "names": input_nodes,
-                },
+            call_params[input_nodes_variable_name] = _lookup_node_ids(
+                gds, input_nodes, node_identifier_property
             )
-            input_node_ids = df["node_id"].tolist()
-            call_params[input_nodes_variable_name] = input_node_ids
         else:
-            # Handle single  node name
-            query = f"""
-                    MATCH (s)
-                    WHERE toLower(s.{node_identifier_property}) = toLower($name)
-                    RETURN id(s) as node_id
-                    """
-            df = gds.run_cypher(
-                query,
-                params={
-                    "name": input_nodes,
-                },
-            )
-            if not df.empty:
-                call_params[input_nodes_variable_name] = int(df["node_id"].iloc[0])
+            node_ids = _lookup_node_ids(gds, input_nodes, node_identifier_property)
+            if node_ids:
+                call_params[input_nodes_variable_name] = int(node_ids[0])
     elif input_nodes is not None:
         # If input_nodes provided but no nodeIdentifierProperty, pass through as-is
         call_params[input_nodes_variable_name] = input_nodes
@@ -90,18 +125,6 @@ def filter_identifiers(
         raise ValueError(
             "If 'nodes' is provided, 'nodeIdentifierProperty' must also be specified."
         )
-    query = f"""
-            UNWIND $names AS name
-            MATCH (s)
-            WHERE toLower(s.{node_identifier_property}) = toLower(name)
-            RETURN id(s) as node_id
-            """
-    df = gds.run_cypher(
-        query,
-        params={
-            "names": node_names,
-        },
-    )
-    node_ids = df["node_id"].tolist()
+    node_ids = _lookup_node_ids(gds, node_names, node_identifier_property)
     filtered_results = results[results[id_name].isin(node_ids)]
     return filtered_results

--- a/mcp_server/src/mcp_server_neo4j_gds/path_algorithm_handlers.py
+++ b/mcp_server/src/mcp_server_neo4j_gds/path_algorithm_handlers.py
@@ -4,6 +4,7 @@ from typing import Dict, Any
 
 
 from .algorithm_handler import AlgorithmHandler, clean_params
+from .node_translator import translate_identifiers_to_ids
 
 logger = logging.getLogger("mcp_server_neo4j_gds")
 
@@ -32,6 +33,7 @@ def _validate_property_name(name):
     return name
 
 
+
 def _as_node_pairs(gds, node_id_pairs):
     node_ids = [node_id for pair in node_id_pairs for node_id in pair]
     if not node_ids:
@@ -44,25 +46,19 @@ class DijkstraShortestPathHandler(AlgorithmHandler):
     def find_shortest_path(
         self, start_node: str, end_node: str, node_identifier_property: str, **kwargs
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         mode = kwargs.get("mode", "stream")
-        query = f"""
-        MATCH (start)
-        WHERE toLower(start.{node_identifier_property}) CONTAINS toLower($start_name)
-        MATCH (end)
-        WHERE toLower(end.{node_identifier_property}) CONTAINS toLower($end_name)
-        RETURN id(start) as start_id, id(end) as end_id
-        """
-
-        df = self.gds.run_cypher(
-            query, params={"start_name": start_node, "end_name": end_node}
+        node_identifier_property = _validate_property_name(node_identifier_property)
+        resolved = {}
+        translate_identifiers_to_ids(
+            self.gds, start_node, "startNode", node_identifier_property, resolved
         )
-
-        if df.empty:
+        translate_identifiers_to_ids(
+            self.gds, end_node, "endNode", node_identifier_property, resolved
+        )
+        start_node_id = resolved.get("startNode")
+        end_node_id = resolved.get("endNode")
+        if start_node_id is None or end_node_id is None:
             return {"found": False, "message": "One or both node names not found"}
-
-        start_node_id = int(df["start_id"].iloc[0])
-        end_node_id = int(df["end_id"].iloc[0])
 
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(kwargs, ["graphName", "mode"])
@@ -122,20 +118,15 @@ class DeltaSteppingShortestPathHandler(AlgorithmHandler):
     def delta_stepping_shortest_path(
         self, source_node: str, node_identifier_property: str, **kwargs
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         mode = kwargs.get("mode", "stream")
-        query = f"""
-        MATCH (source)
-        WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-        RETURN id(source) as source_id
-        """
-
-        df = self.gds.run_cypher(query, params={"source_name": source_node})
-
-        if df.empty:
+        node_identifier_property = _validate_property_name(node_identifier_property)
+        resolved = {}
+        translate_identifiers_to_ids(
+            self.gds, source_node, "sourceNode", node_identifier_property, resolved
+        )
+        source_node_id = resolved.get("sourceNode")
+        if source_node_id is None:
             return {"found": False, "message": "Source node name not found"}
-
-        source_node_id = int(df["source_id"].iloc[0])
 
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(kwargs, ["graphName", "mode"])
@@ -214,20 +205,15 @@ class DijkstraSingleSourceShortestPathHandler(AlgorithmHandler):
     def dijkstra_single_source_shortest_path(
         self, source_node: str, node_identifier_property: str, **kwargs
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         mode = kwargs.get("mode", "stream")
-        query = f"""
-        MATCH (source)
-        WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-        RETURN id(source) as source_id
-        """
-
-        df = self.gds.run_cypher(query, params={"source_name": source_node})
-
-        if df.empty:
+        node_identifier_property = _validate_property_name(node_identifier_property)
+        resolved = {}
+        translate_identifiers_to_ids(
+            self.gds, source_node, "sourceNode", node_identifier_property, resolved
+        )
+        source_node_id = resolved.get("sourceNode")
+        if source_node_id is None:
             return {"found": False, "message": "Source node name not found"}
-
-        source_node_id = int(df["source_id"].iloc[0])
 
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(kwargs, ["graphName", "mode"])
@@ -309,25 +295,19 @@ class AStarShortestPathHandler(AlgorithmHandler):
         node_identifier_property: str,
         **kwargs,
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         mode = kwargs.get("mode", "stream")
-        query = f"""
-        MATCH (source)
-        WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-        MATCH (target)
-        WHERE toLower(target.{node_identifier_property}) CONTAINS toLower($target_name)
-        RETURN id(source) as source_id, id(target) as target_id
-        """
-
-        df = self.gds.run_cypher(
-            query, params={"source_name": source_node, "target_name": target_node}
+        node_identifier_property = _validate_property_name(node_identifier_property)
+        resolved = {}
+        translate_identifiers_to_ids(
+            self.gds, source_node, "sourceNode", node_identifier_property, resolved
         )
-
-        if df.empty:
+        translate_identifiers_to_ids(
+            self.gds, target_node, "targetNode", node_identifier_property, resolved
+        )
+        source_node_id = resolved.get("sourceNode")
+        target_node_id = resolved.get("targetNode")
+        if source_node_id is None or target_node_id is None:
             return {"found": False, "message": "One or both node names not found"}
-
-        source_node_id = int(df["source_id"].iloc[0])
-        target_node_id = int(df["target_id"].iloc[0])
 
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(kwargs, ["graphName", "mode"])
@@ -393,25 +373,19 @@ class YensShortestPathsHandler(AlgorithmHandler):
         node_identifier_property: str,
         **kwargs,
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         mode = kwargs.get("mode", "stream")
-        query = f"""
-        MATCH (source)
-        WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-        MATCH (target)
-        WHERE toLower(target.{node_identifier_property}) CONTAINS toLower($target_name)
-        RETURN id(source) as source_id, id(target) as target_id
-        """
-
-        df = self.gds.run_cypher(
-            query, params={"source_name": source_node, "target_name": target_node}
+        node_identifier_property = _validate_property_name(node_identifier_property)
+        resolved = {}
+        translate_identifiers_to_ids(
+            self.gds, source_node, "sourceNode", node_identifier_property, resolved
         )
-
-        if df.empty:
+        translate_identifiers_to_ids(
+            self.gds, target_node, "targetNode", node_identifier_property, resolved
+        )
+        source_node_id = resolved.get("sourceNode")
+        target_node_id = resolved.get("targetNode")
+        if source_node_id is None or target_node_id is None:
             return {"found": False, "message": "One or both node names not found"}
-
-        source_node_id = int(df["source_id"].iloc[0])
-        target_node_id = int(df["target_id"].iloc[0])
 
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(kwargs, ["graphName", "mode"])
@@ -488,20 +462,15 @@ class MinimumWeightSpanningTreeHandler(AlgorithmHandler):
     def minimum_weight_spanning_tree(
         self, source_node: str, node_identifier_property: str, **kwargs
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         mode = kwargs.get("mode", "stream")
-        query = f"""
-        MATCH (source)
-        WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-        RETURN id(source) as source_id
-        """
-
-        df = self.gds.run_cypher(query, params={"source_name": source_node})
-
-        if df.empty:
+        node_identifier_property = _validate_property_name(node_identifier_property)
+        resolved = {}
+        translate_identifiers_to_ids(
+            self.gds, source_node, "sourceNode", node_identifier_property, resolved
+        )
+        source_node_id = resolved.get("sourceNode")
+        if source_node_id is None:
             return {"found": False, "message": "Source node name not found"}
-
-        source_node_id = int(df["source_id"].iloc[0])
 
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(kwargs, ["graphName", "mode"])
@@ -586,22 +555,15 @@ class MinimumDirectedSteinerTreeHandler(AlgorithmHandler):
         node_identifier_property: str,
         **kwargs,
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         # Find source node ID
-        source_query = f"""
-        MATCH (source)
-        WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-        RETURN id(source) as source_id
-        """
-
-        source_df = self.gds.run_cypher(
-            source_query, params={"source_name": source_node}
+        node_identifier_property = _validate_property_name(node_identifier_property)
+        resolved = {}
+        translate_identifiers_to_ids(
+            self.gds, source_node, "sourceNode", node_identifier_property, resolved
         )
-
-        if source_df.empty:
+        source_node_id = resolved.get("sourceNode")
+        if source_node_id is None:
             return {"found": False, "message": "Source node name not found"}
-
-        source_node_id = int(source_df["source_id"].iloc[0])
 
         # Find target node IDs - ensure ALL target nodes are found
         target_node_ids = []
@@ -609,19 +571,20 @@ class MinimumDirectedSteinerTreeHandler(AlgorithmHandler):
         unmatched_targets = []
 
         for target_name in target_nodes:
-            target_query = f"""
-            MATCH (target)
-            WHERE toLower(target.{node_identifier_property}) CONTAINS toLower($target_name)
-            RETURN id(target) as target_id, target.{node_identifier_property} as target_name
-            """
-
-            target_df = self.gds.run_cypher(
-                target_query, params={"target_name": target_name}
+            resolved = {}
+            translate_identifiers_to_ids(
+                self.gds,
+                target_name,
+                "targetNode",
+                node_identifier_property,
+                resolved,
             )
-
-            if not target_df.empty:
-                target_node_ids.append(int(target_df["target_id"].iloc[0]))
-                target_node_names.append(target_df["target_name"].iloc[0])
+            target_node_id = resolved.get("targetNode")
+            if target_node_id is not None:
+                target_node_ids.append(target_node_id)
+                target_node_names.append(
+                    self.gds.util.asNode(target_node_id).get(node_identifier_property)
+                )
             else:
                 unmatched_targets.append(target_name)
 
@@ -824,19 +787,15 @@ class RandomWalkHandler(AlgorithmHandler):
                 }
             node_identifier_property = _validate_property_name(node_identifier_property)
 
-            for source_name in kwargs["sourceNodes"]:
-                source_query = f"""
-                MATCH (source)
-                WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-                RETURN id(source) as source_id
-                """
-
-                source_df = self.gds.run_cypher(
-                    source_query, params={"source_name": source_name}
-                )
-
-                if not source_df.empty:
-                    source_node_ids.append(int(source_df["source_id"].iloc[0]))
+            resolved = {}
+            translate_identifiers_to_ids(
+                self.gds,
+                kwargs["sourceNodes"],
+                "sourceNodes",
+                node_identifier_property,
+                resolved,
+            )
+            source_node_ids = resolved.get("sourceNodes", [])
 
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(kwargs, ["graphName", "nodeIdentifierProperty", "mode"])
@@ -904,40 +863,29 @@ class BreadthFirstSearchHandler(AlgorithmHandler):
     def breadth_first_search(
         self, source_node: str, node_identifier_property: str, **kwargs
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         mode = kwargs.get("mode", "stream")
         # Find source node ID
-        source_query = f"""
-        MATCH (source)
-        WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-        RETURN id(source) as source_id
-        """
-
-        source_df = self.gds.run_cypher(
-            source_query, params={"source_name": source_node}
+        node_identifier_property = _validate_property_name(node_identifier_property)
+        resolved = {}
+        translate_identifiers_to_ids(
+            self.gds, source_node, "sourceNode", node_identifier_property, resolved
         )
-
-        if source_df.empty:
+        source_node_id = resolved.get("sourceNode")
+        if source_node_id is None:
             return {"found": False, "message": "Source node name not found"}
-
-        source_node_id = int(source_df["source_id"].iloc[0])
 
         # Process target nodes if provided
         target_node_ids = []
         if "targetNodes" in kwargs and kwargs["targetNodes"]:
-            for target_name in kwargs["targetNodes"]:
-                target_query = f"""
-                MATCH (target)
-                WHERE toLower(target.{node_identifier_property}) CONTAINS toLower($target_name)
-                RETURN id(target) as target_id
-                """
-
-                target_df = self.gds.run_cypher(
-                    target_query, params={"target_name": target_name}
-                )
-
-                if not target_df.empty:
-                    target_node_ids.append(int(target_df["target_id"].iloc[0]))
+            resolved = {}
+            translate_identifiers_to_ids(
+                self.gds,
+                kwargs["targetNodes"],
+                "targetNodes",
+                node_identifier_property,
+                resolved,
+            )
+            target_node_ids = resolved.get("targetNodes", [])
 
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(kwargs, ["graphName", "nodeIdentifierProperty", "mode"])
@@ -1006,40 +954,29 @@ class DepthFirstSearchHandler(AlgorithmHandler):
     def depth_first_search(
         self, source_node: str, node_identifier_property: str, **kwargs
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         mode = kwargs.get("mode", "stream")
         # Find source node ID
-        source_query = f"""
-        MATCH (source)
-        WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-        RETURN id(source) as source_id
-        """
-
-        source_df = self.gds.run_cypher(
-            source_query, params={"source_name": source_node}
+        node_identifier_property = _validate_property_name(node_identifier_property)
+        resolved = {}
+        translate_identifiers_to_ids(
+            self.gds, source_node, "sourceNode", node_identifier_property, resolved
         )
-
-        if source_df.empty:
+        source_node_id = resolved.get("sourceNode")
+        if source_node_id is None:
             return {"found": False, "message": "Source node name not found"}
-
-        source_node_id = int(source_df["source_id"].iloc[0])
 
         # Process target nodes if provided
         target_node_ids = []
         if "targetNodes" in kwargs and kwargs["targetNodes"]:
-            for target_name in kwargs["targetNodes"]:
-                target_query = f"""
-                MATCH (target)
-                WHERE toLower(target.{node_identifier_property}) CONTAINS toLower($target_name)
-                RETURN id(target) as target_id
-                """
-
-                target_df = self.gds.run_cypher(
-                    target_query, params={"target_name": target_name}
-                )
-
-                if not target_df.empty:
-                    target_node_ids.append(int(target_df["target_id"].iloc[0]))
+            resolved = {}
+            translate_identifiers_to_ids(
+                self.gds,
+                kwargs["targetNodes"],
+                "targetNodes",
+                node_identifier_property,
+                resolved,
+            )
+            target_node_ids = resolved.get("targetNodes", [])
 
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(kwargs, ["graphName", "nodeIdentifierProperty", "mode"])
@@ -1107,23 +1044,16 @@ class BellmanFordSingleSourceShortestPathHandler(AlgorithmHandler):
     def bellman_ford_single_source_shortest_path(
         self, source_node: str, node_identifier_property: str, **kwargs
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         mode = kwargs.get("mode", "stream")
         # Find source node ID
-        source_query = f"""
-        MATCH (source)
-        WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-        RETURN id(source) as source_id
-        """
-
-        source_df = self.gds.run_cypher(
-            source_query, params={"source_name": source_node}
+        node_identifier_property = _validate_property_name(node_identifier_property)
+        resolved = {}
+        translate_identifiers_to_ids(
+            self.gds, source_node, "sourceNode", node_identifier_property, resolved
         )
-
-        if source_df.empty:
+        source_node_id = resolved.get("sourceNode")
+        if source_node_id is None:
             return {"found": False, "message": "Source node name not found"}
-
-        source_node_id = int(source_df["source_id"].iloc[0])
 
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(kwargs, ["graphName", "nodeIdentifierProperty", "mode"])
@@ -1208,17 +1138,15 @@ class LongestPathHandler(AlgorithmHandler):
                 }
             node_identifier_property = _validate_property_name(node_identifier_property)
 
-            for target_name in kwargs["targetNodes"]:
-                target_query = f"""
-                MATCH (target)
-                WHERE toLower(target.{node_identifier_property}) CONTAINS toLower($target_name)
-                RETURN id(target) as target_id
-                """
-                target_df = self.gds.run_cypher(
-                    target_query, params={"target_name": target_name}
-                )
-                if not target_df.empty:
-                    target_node_ids.append(int(target_df["target_id"].iloc[0]))
+            resolved = {}
+            translate_identifiers_to_ids(
+                self.gds,
+                kwargs["targetNodes"],
+                "targetNodes",
+                node_identifier_property,
+                resolved,
+            )
+            target_node_ids = resolved.get("targetNodes", [])
         G = self.gds.graph.get(kwargs.get("graphName"))
         params = clean_params(
             kwargs,
@@ -1293,26 +1221,27 @@ class MaxFlowHandler(AlgorithmHandler):
         node_identifier_property: str,
         **kwargs,
     ):
-        node_identifier_property = _validate_property_name(node_identifier_property)
         mode = kwargs.get("mode", "stream")
+        node_identifier_property = _validate_property_name(node_identifier_property)
         source_node_ids = []
         source_node_names = []
         unmatched_sources = []
 
         for source_name in source_nodes:
-            source_query = f"""
-            MATCH (source)
-            WHERE toLower(source.{node_identifier_property}) CONTAINS toLower($source_name)
-            RETURN id(source) as source_id, source.{node_identifier_property} as source_name
-            """
-
-            source_df = self.gds.run_cypher(
-                source_query, params={"source_name": source_name}
+            resolved = {}
+            translate_identifiers_to_ids(
+                self.gds,
+                source_name,
+                "sourceNode",
+                node_identifier_property,
+                resolved,
             )
-
-            if not source_df.empty:
-                source_node_ids.append(int(source_df["source_id"].iloc[0]))
-                source_node_names.append(source_df["source_name"].iloc[0])
+            source_node_id = resolved.get("sourceNode")
+            if source_node_id is not None:
+                source_node_ids.append(source_node_id)
+                source_node_names.append(
+                    self.gds.util.asNode(source_node_id).get(node_identifier_property)
+                )
             else:
                 unmatched_sources.append(source_name)
 
@@ -1332,19 +1261,20 @@ class MaxFlowHandler(AlgorithmHandler):
         unmatched_targets = []
 
         for target_name in target_nodes:
-            target_query = f"""
-            MATCH (target)
-            WHERE toLower(target.{node_identifier_property}) CONTAINS toLower($target_name)
-            RETURN id(target) as target_id, target.{node_identifier_property} as target_name
-            """
-
-            target_df = self.gds.run_cypher(
-                target_query, params={"target_name": target_name}
+            resolved = {}
+            translate_identifiers_to_ids(
+                self.gds,
+                target_name,
+                "targetNode",
+                node_identifier_property,
+                resolved,
             )
-
-            if not target_df.empty:
-                target_node_ids.append(int(target_df["target_id"].iloc[0]))
-                target_node_names.append(target_df["target_name"].iloc[0])
+            target_node_id = resolved.get("targetNode")
+            if target_node_id is not None:
+                target_node_ids.append(target_node_id)
+                target_node_names.append(
+                    self.gds.util.asNode(target_node_id).get(node_identifier_property)
+                )
             else:
                 unmatched_targets.append(target_name)
 

--- a/mcp_server/src/mcp_server_neo4j_gds/path_algorithm_handlers.py
+++ b/mcp_server/src/mcp_server_neo4j_gds/path_algorithm_handlers.py
@@ -33,7 +33,6 @@ def _validate_property_name(name):
     return name
 
 
-
 def _as_node_pairs(gds, node_id_pairs):
     node_ids = [node_id for pair in node_id_pairs for node_id in pair]
     if not node_ids:

--- a/mcp_server/src/mcp_server_neo4j_gds/path_algorithm_handlers.py
+++ b/mcp_server/src/mcp_server_neo4j_gds/path_algorithm_handlers.py
@@ -950,9 +950,7 @@ class BreadthFirstSearchHandler(AlgorithmHandler):
 
 
 class DepthFirstSearchHandler(AlgorithmHandler):
-    def depth_first_search(
-        self, source_node, node_identifier_property: str, **kwargs
-    ):
+    def depth_first_search(self, source_node, node_identifier_property: str, **kwargs):
         mode = kwargs.get("mode", "stream")
         # Find source node ID
         node_identifier_property = _validate_property_name(node_identifier_property)

--- a/mcp_server/src/mcp_server_neo4j_gds/path_algorithm_handlers.py
+++ b/mcp_server/src/mcp_server_neo4j_gds/path_algorithm_handlers.py
@@ -43,7 +43,7 @@ def _as_node_pairs(gds, node_id_pairs):
 
 class DijkstraShortestPathHandler(AlgorithmHandler):
     def find_shortest_path(
-        self, start_node: str, end_node: str, node_identifier_property: str, **kwargs
+        self, start_node, end_node, node_identifier_property: str, **kwargs
     ):
         mode = kwargs.get("mode", "stream")
         node_identifier_property = _validate_property_name(node_identifier_property)
@@ -115,7 +115,7 @@ class DijkstraShortestPathHandler(AlgorithmHandler):
 
 class DeltaSteppingShortestPathHandler(AlgorithmHandler):
     def delta_stepping_shortest_path(
-        self, source_node: str, node_identifier_property: str, **kwargs
+        self, source_node, node_identifier_property: str, **kwargs
     ):
         mode = kwargs.get("mode", "stream")
         node_identifier_property = _validate_property_name(node_identifier_property)
@@ -202,7 +202,7 @@ class DeltaSteppingShortestPathHandler(AlgorithmHandler):
 
 class DijkstraSingleSourceShortestPathHandler(AlgorithmHandler):
     def dijkstra_single_source_shortest_path(
-        self, source_node: str, node_identifier_property: str, **kwargs
+        self, source_node, node_identifier_property: str, **kwargs
     ):
         mode = kwargs.get("mode", "stream")
         node_identifier_property = _validate_property_name(node_identifier_property)
@@ -289,8 +289,8 @@ class DijkstraSingleSourceShortestPathHandler(AlgorithmHandler):
 class AStarShortestPathHandler(AlgorithmHandler):
     def a_star_shortest_path(
         self,
-        source_node: str,
-        target_node: str,
+        source_node,
+        target_node,
         node_identifier_property: str,
         **kwargs,
     ):
@@ -367,8 +367,8 @@ class AStarShortestPathHandler(AlgorithmHandler):
 class YensShortestPathsHandler(AlgorithmHandler):
     def yens_shortest_paths(
         self,
-        source_node: str,
-        target_node: str,
+        source_node,
+        target_node,
         node_identifier_property: str,
         **kwargs,
     ):
@@ -459,7 +459,7 @@ class YensShortestPathsHandler(AlgorithmHandler):
 
 class MinimumWeightSpanningTreeHandler(AlgorithmHandler):
     def minimum_weight_spanning_tree(
-        self, source_node: str, node_identifier_property: str, **kwargs
+        self, source_node, node_identifier_property: str, **kwargs
     ):
         mode = kwargs.get("mode", "stream")
         node_identifier_property = _validate_property_name(node_identifier_property)
@@ -549,7 +549,7 @@ class MinimumWeightSpanningTreeHandler(AlgorithmHandler):
 class MinimumDirectedSteinerTreeHandler(AlgorithmHandler):
     def minimum_directed_steiner_tree(
         self,
-        source_node: str,
+        source_node,
         target_nodes: list,
         node_identifier_property: str,
         **kwargs,
@@ -591,7 +591,7 @@ class MinimumDirectedSteinerTreeHandler(AlgorithmHandler):
         if unmatched_targets:
             return {
                 "found": False,
-                "message": f"The following target nodes were not found: {', '.join(unmatched_targets)}",
+                "message": f"The following target nodes were not found: {', '.join(map(str, unmatched_targets))}",
             }
 
         if not target_node_ids:
@@ -860,7 +860,7 @@ class RandomWalkHandler(AlgorithmHandler):
 
 class BreadthFirstSearchHandler(AlgorithmHandler):
     def breadth_first_search(
-        self, source_node: str, node_identifier_property: str, **kwargs
+        self, source_node, node_identifier_property: str, **kwargs
     ):
         mode = kwargs.get("mode", "stream")
         # Find source node ID
@@ -951,7 +951,7 @@ class BreadthFirstSearchHandler(AlgorithmHandler):
 
 class DepthFirstSearchHandler(AlgorithmHandler):
     def depth_first_search(
-        self, source_node: str, node_identifier_property: str, **kwargs
+        self, source_node, node_identifier_property: str, **kwargs
     ):
         mode = kwargs.get("mode", "stream")
         # Find source node ID
@@ -1041,7 +1041,7 @@ class DepthFirstSearchHandler(AlgorithmHandler):
 
 class BellmanFordSingleSourceShortestPathHandler(AlgorithmHandler):
     def bellman_ford_single_source_shortest_path(
-        self, source_node: str, node_identifier_property: str, **kwargs
+        self, source_node, node_identifier_property: str, **kwargs
     ):
         mode = kwargs.get("mode", "stream")
         # Find source node ID
@@ -1248,7 +1248,7 @@ class MaxFlowHandler(AlgorithmHandler):
         if unmatched_sources:
             return {
                 "found": False,
-                "message": f"The following source nodes were not found: {', '.join(unmatched_sources)}",
+                "message": f"The following source nodes were not found: {', '.join(map(str, unmatched_sources))}",
             }
 
         if not source_node_ids:
@@ -1281,7 +1281,7 @@ class MaxFlowHandler(AlgorithmHandler):
         if unmatched_targets:
             return {
                 "found": False,
-                "message": f"The following target nodes were not found: {', '.join(unmatched_targets)}",
+                "message": f"The following target nodes were not found: {', '.join(map(str, unmatched_targets))}",
             }
 
         if not target_node_ids:

--- a/mcp_server/src/mcp_server_neo4j_gds/path_algorithm_specs.py
+++ b/mcp_server/src/mcp_server_neo4j_gds/path_algorithm_specs.py
@@ -21,12 +21,12 @@ path_tool_definitions = [
                     "description": "Required when mode is 'mutate'. The relationship type for new relationships written to the projected graph.",
                 },
                 "start_node": {
-                    "type": "string",
-                    "description": "Name of the starting node",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
+                    "description": "Identifier of the starting node. Use a JSON number when the identifier property is numeric.",
                 },
                 "end_node": {
-                    "type": "string",
-                    "description": "Name of the ending node",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
+                    "description": "Identifier of the ending node. Use a JSON number when the identifier property is numeric.",
                 },
                 "nodeIdentifierProperty": {
                     "type": "string",
@@ -69,7 +69,7 @@ path_tool_definitions = [
                     "description": "Required when mode is 'mutate'. The relationship type for new relationships written to the projected graph.",
                 },
                 "sourceNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the source node to find shortest paths from.",
                 },
                 "nodeIdentifierProperty": {
@@ -111,7 +111,7 @@ path_tool_definitions = [
                     "description": "Required when mode is 'mutate'. The relationship type for new relationships written to the projected graph.",
                 },
                 "sourceNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the source node to find shortest paths from.",
                 },
                 "nodeIdentifierProperty": {
@@ -155,11 +155,11 @@ path_tool_definitions = [
                     "description": "Required when mode is 'mutate'. The relationship type for new relationships written to the projected graph.",
                 },
                 "sourceNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the source node to find shortest path from.",
                 },
                 "targetNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the target node to find shortest path to.",
                 },
                 "nodeIdentifierProperty": {
@@ -218,11 +218,11 @@ path_tool_definitions = [
                     "description": "Required when mode is 'mutate'. The relationship type for new relationships written to the projected graph.",
                 },
                 "sourceNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the source node to find shortest paths from.",
                 },
                 "targetNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the target node to find shortest paths to.",
                 },
                 "nodeIdentifierProperty": {
@@ -276,7 +276,7 @@ path_tool_definitions = [
                     "description": "Required when mode is 'mutate'. The relationship type for new relationships written to the projected graph.",
                 },
                 "sourceNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the starting source node.",
                 },
                 "nodeIdentifierProperty": {
@@ -317,12 +317,12 @@ path_tool_definitions = [
                     "description": "Name of the projected graph to run the algorithm on. Use project_graph_cypher to create a graph first.",
                 },
                 "sourceNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the starting source node.",
                 },
                 "targetNodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of target node names to connect in the steiner tree.",
                 },
                 "nodeIdentifierProperty": {
@@ -435,7 +435,7 @@ path_tool_definitions = [
                 },
                 "sourceNodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "The list of nodes from which to do a random walk.",
                 },
                 "nodeIdentifierProperty": {
@@ -494,7 +494,7 @@ path_tool_definitions = [
                     "description": "Required when mode is 'mutate'. The relationship type for new relationships written to the projected graph.",
                 },
                 "sourceNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the starting source node.",
                 },
                 "nodeIdentifierProperty": {
@@ -503,7 +503,7 @@ path_tool_definitions = [
                 },
                 "targetNodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "Names of target nodes. Traversal terminates when any target node is visited.",
                 },
                 "maxDepth": {
@@ -538,7 +538,7 @@ path_tool_definitions = [
                     "description": "Required when mode is 'mutate'. The relationship type for new relationships written to the projected graph.",
                 },
                 "sourceNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the starting source node.",
                 },
                 "nodeIdentifierProperty": {
@@ -547,7 +547,7 @@ path_tool_definitions = [
                 },
                 "targetNodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "Names of target nodes. Traversal terminates when any target node is visited.",
                 },
                 "maxDepth": {
@@ -588,7 +588,7 @@ path_tool_definitions = [
                     "description": "Required when mode is 'mutate'. The relationship type for new relationships written to the projected graph.",
                 },
                 "sourceNode": {
-                    "type": "string",
+                    "anyOf": [{"type": "string"}, {"type": "number"}],
                     "description": "Name of the starting source node.",
                 },
                 "nodeIdentifierProperty": {
@@ -620,7 +620,7 @@ path_tool_definitions = [
                 },
                 "targetNodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of target node names to filter results. Only paths ending at these nodes will be returned.",
                 },
                 "nodeIdentifierProperty": {
@@ -661,12 +661,12 @@ path_tool_definitions = [
                 },
                 "sourceNodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of source node names from which flow originates.",
                 },
                 "targetNodes": {
                     "type": "array",
-                    "items": {"type": "string"},
+                    "items": {"anyOf": [{"type": "string"}, {"type": "number"}]},
                     "description": "List of target node names to which flow is sent.",
                 },
                 "nodeIdentifierProperty": {

--- a/mcp_server/src/mcp_server_neo4j_gds/similarity_algorithm_specs.py
+++ b/mcp_server/src/mcp_server_neo4j_gds/similarity_algorithm_specs.py
@@ -15,11 +15,12 @@ similarity_tool_definitions = [
                     "anyOf": [
                         {
                             "type": "array",
-                            "items": {"type": "string"},
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "number"}]
+                            },
                         },
-                        {
-                            "type": "string",
-                        },
+                        {"type": "string"},
+                        {"type": "number"},
                     ],
                     "description": "The source node filter to apply. Accepts a List of node names, or a single label.",
                 },
@@ -27,11 +28,12 @@ similarity_tool_definitions = [
                     "anyOf": [
                         {
                             "type": "array",
-                            "items": {"type": "string"},
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "number"}]
+                            },
                         },
-                        {
-                            "type": "string",
-                        },
+                        {"type": "string"},
+                        {"type": "number"},
                     ],
                     "description": "The target node filter to apply. Accepts a List of node names, or a single label.",
                 },
@@ -130,11 +132,12 @@ similarity_tool_definitions = [
                     "anyOf": [
                         {
                             "type": "array",
-                            "items": {"type": "string"},
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "number"}]
+                            },
                         },
-                        {
-                            "type": "string",
-                        },
+                        {"type": "string"},
+                        {"type": "number"},
                     ],
                     "description": "The source node filter to apply. Accepts a List of node names, or a single label.",
                 },
@@ -142,11 +145,12 @@ similarity_tool_definitions = [
                     "anyOf": [
                         {
                             "type": "array",
-                            "items": {"type": "string"},
+                            "items": {
+                                "anyOf": [{"type": "string"}, {"type": "number"}]
+                            },
                         },
-                        {
-                            "type": "string",
-                        },
+                        {"type": "string"},
+                        {"type": "number"},
                     ],
                     "description": "The target node filter to apply. Accepts a List of node names, or a single label.",
                 },

--- a/mcp_server/tests/test_path_algorithms.py
+++ b/mcp_server/tests/test_path_algorithms.py
@@ -932,3 +932,69 @@ async def test_find_shortest_path_rejects_injection_in_node_identifier_property(
     assert "Invalid nodeIdentifierProperty" in result_text
     # The injected marker must not have made it back through Neo4j.
     assert "pwned" not in result_text
+
+
+def test_lookup_node_ids_builds_numeric_and_string_queries():
+    from mcp_server_neo4j_gds import node_translator
+
+    captured = []
+
+    class FakeGds:
+        def run_cypher(self, query, params=None):
+            captured.append((query, params))
+
+            class DF:
+                def __getitem__(self, key):
+                    class Col:
+                        def tolist(self):
+                            return []
+
+                    return Col()
+
+            return DF()
+
+    node_translator._lookup_node_ids(FakeGds(), "42", "movieId")
+    assert "toLower" not in captured[0][0]
+    assert captured[0][1]["names"] == [42]
+
+    captured.clear()
+    node_translator._lookup_node_ids(FakeGds(), "Bayswater", "name")
+    assert "CONTAINS" in captured[0][0]
+
+
+@pytest.mark.asyncio
+async def test_find_shortest_path_with_integer_identifier(
+    mcp_client, projected_test_graph, neo4j_container
+):
+    from neo4j import GraphDatabase
+
+    driver = GraphDatabase.driver(neo4j_container, auth=("neo4j", "testpassword"))
+    try:
+        with driver.session() as session:
+            session.run(
+                """
+                MATCH (a:UndergroundStation {name: 'Bayswater'})
+                MATCH (b:UndergroundStation {name: 'Westbourne Park'})
+                SET a.testId = 1001, b.testId = 1002
+                """
+            )
+
+        result = await mcp_client.call_tool(
+            "find_shortest_path",
+            {
+                "start_node": "1001",
+                "end_node": "1002",
+                "nodeIdentifierProperty": "testId",
+                "relationship_property": "time",
+                "graphName": projected_test_graph,
+            },
+        )
+        result_data = json.loads(result[0]["text"])
+        assert result_data["totalCost"] == 5.0
+        assert "Bayswater" in result_data["nodeNames"][0]
+    finally:
+        with driver.session() as session:
+            session.run(
+                "MATCH (n:UndergroundStation) WHERE n.testId IS NOT NULL REMOVE n.testId"
+            )
+        driver.close()

--- a/mcp_server/tests/test_path_algorithms.py
+++ b/mcp_server/tests/test_path_algorithms.py
@@ -943,9 +943,7 @@ async def test_find_shortest_path_with_integer_identifier(
 ):
     from neo4j import GraphDatabase
 
-    driver = GraphDatabase.driver(
-        neo4j_container, auth=(NEO4J_USER, NEO4J_PASSWORD)
-    )
+    driver = GraphDatabase.driver(neo4j_container, auth=(NEO4J_USER, NEO4J_PASSWORD))
     try:
         with driver.session() as session:
             session.run(

--- a/mcp_server/tests/test_path_algorithms.py
+++ b/mcp_server/tests/test_path_algorithms.py
@@ -2,6 +2,9 @@ import pytest
 import json
 import re
 
+NEO4J_USER = "neo4j"
+NEO4J_PASSWORD = "testpassword"
+
 
 @pytest.mark.asyncio
 async def test_find_shortest_path(mcp_client, projected_test_graph):
@@ -934,56 +937,30 @@ async def test_find_shortest_path_rejects_injection_in_node_identifier_property(
     assert "pwned" not in result_text
 
 
-def test_lookup_node_ids_builds_numeric_and_string_queries():
-    from mcp_server_neo4j_gds import node_translator
-
-    captured = []
-
-    class FakeGds:
-        def run_cypher(self, query, params=None):
-            captured.append((query, params))
-
-            class DF:
-                def __getitem__(self, key):
-                    class Col:
-                        def tolist(self):
-                            return []
-
-                    return Col()
-
-            return DF()
-
-    node_translator._lookup_node_ids(FakeGds(), "42", "movieId")
-    assert "toLower" not in captured[0][0]
-    assert captured[0][1]["names"] == [42]
-
-    captured.clear()
-    node_translator._lookup_node_ids(FakeGds(), "Bayswater", "name")
-    assert "CONTAINS" in captured[0][0]
-
-
 @pytest.mark.asyncio
 async def test_find_shortest_path_with_integer_identifier(
     mcp_client, projected_test_graph, neo4j_container
 ):
     from neo4j import GraphDatabase
 
-    driver = GraphDatabase.driver(neo4j_container, auth=("neo4j", "testpassword"))
+    driver = GraphDatabase.driver(
+        neo4j_container, auth=(NEO4J_USER, NEO4J_PASSWORD)
+    )
     try:
         with driver.session() as session:
             session.run(
                 """
                 MATCH (a:UndergroundStation {name: 'Bayswater'})
                 MATCH (b:UndergroundStation {name: 'Westbourne Park'})
-                SET a.testId = 1001, b.testId = 1002
+                SET a.testId = 1001, b.testId = 10010
                 """
             )
 
         result = await mcp_client.call_tool(
             "find_shortest_path",
             {
-                "start_node": "1001",
-                "end_node": "1002",
+                "start_node": 1001,
+                "end_node": 10010,
                 "nodeIdentifierProperty": "testId",
                 "relationship_property": "time",
                 "graphName": projected_test_graph,


### PR DESCRIPTION
Node lookup used toLower(...) for every identifier, which broke when the identifier was numeric

<img width="548" height="245" alt="movies database - userIds" src="https://github.com/user-attachments/assets/ce9dbdb8-f7b9-4ba8-8a79-99b33a6088c9" />

Now it checks the property type first: numeric properties get an exact match, string properties get case-insensitive CONTAINS match

Path handlers now use this lookup too. Other handlers (similarity, centrality) previously matched exactly regardless of type, both are now consistent by property type
